### PR TITLE
Fixes for local Docker deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,18 @@ server-run:  ## run the Nginx CGHousing container
 		-p 6080:80 \
 		cg-nginx:1.0
 
+server-run-dev:  ## run the Nginx CGHousing container in dev mode
+	docker run \
+		-d \
+		--network cg \
+		--name cg-server \
+		-v "$(ROOT_DIR)/data/static:/cghousing-static:ro" \
+		-v "$(ROOT_DIR)/src/nginx/html:/var/www/html" \
+		-v "$(ROOT_DIR)/src/nginx/etc/nginx.conf:/etc/nginx/nginx.conf" \
+		-v "$(ROOT_DIR)/src/nginx/etc/cg-dev:/etc/nginx/sites-enabled/cg-dev" \
+		-p 6080:80 \
+		cg-nginx:1.0
+
 server-sh:  ## run sh shell in the Nginx CGHousing container
 	@docker run \
 		-it \

--- a/README.rst
+++ b/README.rst
@@ -44,10 +44,14 @@ Build the Nginx image::
 
     $ make server-build
 
-Add the following line to ``/etc/hosts`` file so that you can navigate to
-http://cghousing.org:6080 to view the application::
+Run the Nginx image in local dev mode::
 
-    127.0.0.1 cghousing.org
+    $ make server-run-dev
+
+Add the following line to ``/etc/hosts`` file so that you can navigate to
+http://dev.cghousing.org:6080 to view the application::
+
+    127.0.0.1 dev.cghousing.org
 
 
 TODOs / Somedays

--- a/src/nginx/etc/cg-dev
+++ b/src/nginx/etc/cg-dev
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name cghousing.org www.cghousing.org;
+    server_name dev.cghousing.org www.dev.cghousing.org;
     location / {
         proxy_set_header        Host $http_host;
         proxy_set_header        X-Real-IP $remote_addr;


### PR DESCRIPTION
- Add make rule `server-run-dev` for running the Nginx CGHousing container in dev mode.
- Improve instructions for running in local dev mode.
- Use server name dev.cghousing.org in dev mode.
- Use cghousing submodule that fetches Pip correctly.